### PR TITLE
Escape single backslashes for Windows & periods for kicks

### DIFF
--- a/plugin/cyclecolor.vim
+++ b/plugin/cyclecolor.vim
@@ -78,13 +78,13 @@ function! s:CycleColor(direction)
 		" Find the current file name, and select the next one.
 		" No substitution will take place if the current file is not
 		"   found or is the last in the list.
-		let nextfile = substitute(s:schemes, '.*\n'.s:currentfile.'\n\([^\x0A]\+\)\n.*', '\1', '')
+		let nextfile = substitute(s:schemes, '.*\n'.escape(s:currentfile, '\.').'\n\([^\x0A]\+\)\n.*', '\1', '')
 		" If the above worked, there will be no control chars in
 		"   nextfile, so this will not substitute; otherwise, this will
 		"   choose the first file in the list.
 		let nextfile = substitute(nextfile, '\n\+\([^\x0A]\+\)\n.*', '\1', '')
 	else
-		let nextfile = substitute(s:schemes, '.*\n\([^\x0A]\+\)\n'.s:currentfile.'\n.*', '\1', '')
+		let nextfile = substitute(s:schemes, '.*\n\([^\x0A]\+\)\n'.escape(s:currentfile, '\.').'\n.*', '\1', '')
 		let nextfile = substitute(nextfile, '.*\n\([^\x0A]\+\)\n\+', '\1', '')
 	endif
 


### PR DESCRIPTION
This wasn't working for me on Windows, but escaping the backslashes in `s:currentfile` fixed it.
